### PR TITLE
Use the correct location for ypdomainname (bnc#916031)

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb  4 11:01:53 UTC 2015 - ancor@suse.com
+
+- Use correct location for ypdomainname (bnc#916031)
+- 3.1.12
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:31 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-client
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -909,7 +909,7 @@ module Yast
       @slp_domain = {} if @slp_domain == nil
 
       out = SCR.Execute(path(".target.bash_output"), "/usr/bin/ypdomainname")
-      @domain = out["stdout"].strip
+      @domain = out["stdout"].chomp
       @old_domain = @domain
 
       @dhcpcd_running = SCR.Execute(

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -908,10 +908,8 @@ module Yast
       @multidomain_broadcast = {} if @multidomain_broadcast == nil
       @slp_domain = {} if @slp_domain == nil
 
-      out = Convert.to_map(
-        SCR.Execute(path(".target.bash_output"), "/bin/ypdomainname")
-      )
-      @domain = Builtins.deletechars(Ops.get_string(out, "stdout", ""), "\n")
+      out = SCR.Execute(path(".target.bash_output"), "/usr/bin/ypdomainname")
+      @domain = out["stdout"].strip
       @old_domain = @domain
 
       @dhcpcd_running = SCR.Execute(

--- a/testsuite/tests/readwrite.out
+++ b/testsuite/tests/readwrite.out
@@ -1,7 +1,7 @@
 Dump	no policy
 Read	.sysconfig.network.config.NETCONFIG_NIS_POLICY ""
 Dir	.sysconfig.network.config: ["NETCONFIG_NIS_POLICY"]
-Execute	.target.bash_output "/bin/ypdomainname" $["exit":0, "stderr":"", "stdout":"mydomain\n"]
+Execute	.target.bash_output "/usr/bin/ypdomainname" $["exit":0, "stderr":"", "stdout":"mydomain\n"]
 Execute	.target.bash "ls /var/run/dhcpcd-*.pid" 0
 Read	.sysconfig.ypbind.YPBIND_LOCAL_ONLY "no"
 Read	.sysconfig.ypbind.YPBIND_BROADCAST "no"
@@ -27,7 +27,7 @@ Return	true
 Dump	auto policy
 Read	.sysconfig.network.config.NETCONFIG_NIS_POLICY "auto"
 Dir	.sysconfig.network.config: ["NETCONFIG_NIS_POLICY"]
-Execute	.target.bash_output "/bin/ypdomainname" $["exit":0, "stderr":"", "stdout":"mydomain\n"]
+Execute	.target.bash_output "/usr/bin/ypdomainname" $["exit":0, "stderr":"", "stdout":"mydomain\n"]
 Execute	.target.bash "ls /var/run/dhcpcd-*.pid" 0
 Read	.sysconfig.ypbind.YPBIND_LOCAL_ONLY "no"
 Read	.sysconfig.ypbind.YPBIND_BROADCAST "no"


### PR DESCRIPTION
 * It's actually placed in /usr/bin for SLE12, openSUSE13.2 and Factory.
 * The old location works in SLE12 and 13.2 because there is still a symlink added for compatibility (that will be removed at some point)