### PR TITLE
added libnsl-devel to BuildRequires for upstream changes

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 11 07:34:10 UTC 2017 - jsrain@suse.cz
+
+- added libnsl-devel to BuildRequires for upstream changes
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed May 24 09:14:54 CEST 2017 - schubi@suse.de
 
 - Added yp-tools to the requirements in order to call ypdomainname

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-client
-Version:        3.2.1
+Version:        4.0.0
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 
@@ -29,6 +29,7 @@ License:        GPL-2.0
 # SuSEfirewall2_* services merged into one service yast2-2.23.17
 BuildRequires:	yast2 >= 2.23.17
 BuildRequires:	gcc-c++ perl-XML-Writer doxygen yast2-core-devel yast2-testsuite yast2-pam update-desktop-files libtool
+BuildRequires:  libnsl-devel
 BuildRequires:  yast2-devtools >= 3.1.10
 # Wizard::SetDesktopTitleAndIcon
 Requires:	yast2 >= 2.21.22


### PR DESCRIPTION
Currently, it is failing in Factory staging:   https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:B/yast2-nis-client/standard/i586