### PR TITLE
Link aginast libtirpc, sunrpc is deprecated and has no IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM yastdevel/cpp
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   yast2-testsuite \
-  yast2-pam
+  yast2-pam \
+  libnsl-devel \
+  libtirpc-devel
 
 COPY . /usr/src/app
 

--- a/agent-ypserv/src/Makefile.am
+++ b/agent-ypserv/src/Makefile.am
@@ -2,12 +2,12 @@
 # Makefile.am for nis-client/agent-ypserv/src
 #
 
-AM_CXXFLAGS = -DY2LOG=\"agent-ypserv\"
+AM_CXXFLAGS = -DY2LOG=\"agent-ypserv\" -I/usr/include/tirpc
 
 noinst_LTLIBRARIES = libFindYpserv.la
 
 libFindYpserv_la_SOURCES = FindYpserv.cc FindYpserv.h
-libFindYpserv_la_LIBADD = -lnsl
+libFindYpserv_la_LIBADD = -lnsl -ltirpc
 
 plugin_LTLIBRARIES = libpy2ag_ypserv.la
 

--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 14 14:25:11 CET 2017 - kukuk@suse.de
+
+- Link ypserv agent against libtirpc, sunrpc is deprecated and does
+  not support IPv6
+
+-------------------------------------------------------------------
 Mon Sep 11 07:34:10 UTC 2017 - jsrain@suse.cz
 
 - added libnsl-devel to BuildRequires for upstream changes

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -30,6 +30,7 @@ License:        GPL-2.0
 BuildRequires:	yast2 >= 2.23.17
 BuildRequires:	gcc-c++ perl-XML-Writer doxygen yast2-core-devel yast2-testsuite yast2-pam update-desktop-files libtool
 BuildRequires:  libnsl-devel
+BuildRequires:  libtirpc-devel
 BuildRequires:  yast2-devtools >= 3.1.10
 # Wizard::SetDesktopTitleAndIcon
 Requires:	yast2 >= 2.21.22


### PR DESCRIPTION
libnsl supports IPv6, sunrpc not, so there is currently a mismatch in the code. And sunrpc will be removed in the near future, so switch completly to tirpc.