### PR TITLE
Prevent UI syntax error due to nil in widget term (bsc#1126515)

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 11 16:43:56 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent UI syntax error due to nil in widget term (bsc#1126515)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Dec  4 11:09:02 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-client
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 

--- a/src/include/nis/ui.rb
+++ b/src/include/nis/ui.rb
@@ -694,7 +694,7 @@ module Yast
 
       local_only = Nis.local_only
       broken_server = Nis.broken_server
-      options = Nis.options
+      options = Nis.options || ""
 
       contents = HSquash(
         VBox(


### PR DESCRIPTION
## Trello

https://trello.com/c/tnXzMwq3/
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1126515

## Problem

![nis-client-main](https://user-images.githubusercontent.com/11538225/54141629-58c0ff00-4426-11e9-82e7-1c3e925b766c.png)

Red UI error popup "UI syntax error" when the user clicks on the _**Expert**_ button:

![ui-syntax-error](https://user-images.githubusercontent.com/11538225/54141641-5f4f7680-4426-11e9-9bca-d95458646579.png)


y2logs:

```
2019-03-06 10:56:14 <3> linux-wxru(4791) [libycp] modules/Wizard.rb:830
  Invalid arguments for the InputField widget:
  `InputField (`id (`options), `opt (`hstretch), "Other &ypbind options", nil)

2019-03-06 10:56:14 <2> linux-wxru(4791) [ui] YCPDialogParser.cc(parseInputField):1821
  THROW: Invalid arguments for the InputField widget

2019-03-06 10:56:14 <2> linux-wxru(4791) [ui] YCP_UI.cc(ReplaceWidget):874
  CAUGHT: Invalid arguments for the InputField widget


2019-03-06 10:56:14 <3> linux-wxru(4791) [libycp] modules/Wizard.rb:830
  UI::ReplaceWidget() failed:

UI::ReplaceWidget( `id (`contents),
  `HSquash (
    `VBox (
      `Frame ("Expert settings",
      `VBox (
        `VSpacing (0.2),
        `Left ( `CheckBox (`id (`remote), "Ans&wer Remote Hosts", true)),
        `Left (`CheckBox (`id (`broken_server), "Br&oken server", false)),
        `VSpacing (0.2),
        `InputField (`id (`options), `opt (`hstretch), "Other &ypbind options", nil),
        `VSpacing (0.2))
      ),
      `VSpacing ()
    )
  )
)

2019-03-06 10:56:20 <2> linux-wxru(4791) [ui] YWidget.cc(findWidget):635
  THROW:    No widget with ID options

2019-03-06 10:56:20 <2> linux-wxru(4791) [ui] YCP_UI.cc(QueryWidget):806
  CAUGHT:   No widget with ID options

2019-03-06 10:56:20 <3> linux-wxru(4791) [libycp] nis/ui.rb:753
  UI::QueryWidget failed: UI::QueryWidget( `id (`options), `Value )
```

## Cause

The NIS options might be _nil_, and this was not caught.

https://github.com/yast/yast-nis-client/blob/master/src/include/nis/ui.rb#L697

## Fix

Provide a fallback if those options are _nil_.

## Screenshot

![nis-client-expert-settings](https://user-images.githubusercontent.com/11538225/54141791-a178b800-4426-11e9-9697-b4a948b1afc1.png)

## Test

Manual test on my workstation.

Since I could not reproduce the problem, neither on my workstation nor in a freshly installed TW, I hacked up the code slightly to actively set `Nis.options = nil` before the changed line and tested with that.

Without the fix, it shows the error pop-up as shown above, with the fix, it works as expected, i.e. as shown in the last screenshot here.