### PR TITLE
Preserve NSS sources

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  7 16:09:20 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Preserve NSS database sources when adding nis to nsswitch.conf
+  file (bsc#1162916).
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Aug 27 18:23:15 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nis-client
 Summary:        YaST2 - Network Information Services (NIS, YP) Configuration
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 Group:          System/YaST

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -1089,7 +1089,7 @@ module Yast
             if db == "netgroup"
               db_l = ["nis"]
             else
-              db_l = ["files", "nis"]
+              db_l << "nis"
             end
             Nsswitch.WriteDb(db, db_l)
           end
@@ -1109,7 +1109,7 @@ module Yast
         Builtins.foreach(nis_dbs) do |db|
           db_l = Nsswitch.ReadDb(db)
           db_l = Builtins.filter(db_l) { |s| s != "nis" }
-          db_l = ["files"] if db_l == []
+          db_l = ["files", "usrfiles"] if db_l == []
           Nsswitch.WriteDb(db, db_l)
         end
       end


### PR DESCRIPTION
## Problem

When NIS is configured, the */etc/nsswitch.conf* file is updated to add the *nis* source to the proper databases. But, when doing so, previous sources like *usrfiles* are lost.

* https://bugzilla.suse.com/show_bug.cgi?id=1162916
* https://trello.com/c/nNDtx1W3/1626-ostumbleweed-p1-1162916-yast-removes-usrfiles-entries-from-etc-nsswitchconf

## Solution

Preserve database sources when adding nis.

## Testing

* Tested manually
