### PR TITLE
Reduce profile size and do not export nil values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,13 +43,6 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   Max: 7
 
-# Offense count: 13
-Lint/UselessAssignment:
-  Exclude:
-    - 'src/clients/nis.rb'
-    - 'src/include/nis/ui.rb'
-    - 'src/modules/Nis.rb'
-
 # Offense count: 1
 Metrics/AbcSize:
   Max: 339
@@ -57,7 +50,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 908
+  Max: 909
 
 # Offense count: 1
 Metrics/CyclomaticComplexity:
@@ -66,11 +59,11 @@ Metrics/CyclomaticComplexity:
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 369
+  Max: 372
 
 # Offense count: 1
 Metrics/PerceivedComplexity:
-  Max: 62
+  Max: 63
 
 # Offense count: 2
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
@@ -99,19 +92,6 @@ Naming/UncommunicativeMethodParamName:
     - 'src/include/nis/ui.rb'
     - 'src/modules/Nis.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: Keywords.
-# Keywords: TODO, FIXME, OPTIMIZE, HACK, REVIEW
-Style/CommentAnnotation:
-  Exclude:
-    - 'src/clients/nis.rb'
-
-# Offense count: 1
-Style/CommentedKeyword:
-  Exclude:
-    - 'src/modules/Nis.rb'
-
 # Offense count: 6
 Style/Documentation:
   Exclude:
@@ -134,12 +114,6 @@ Style/Documentation:
 # Offense count: 3
 # Configuration parameters: MinBodyLength.
 Style/GuardClause:
-  Exclude:
-    - 'src/include/nis/ui.rb'
-    - 'src/modules/Nis.rb'
-
-# Offense count: 3
-Style/MultilineTernaryOperator:
   Exclude:
     - 'src/include/nis/ui.rb'
     - 'src/modules/Nis.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,162 @@
+# use the shared Yast defaults
+inherit_from:
+  - /usr/share/YaST2/data/devtools/data/rubocop-0.71.0_yast_style.yml
+
+# this needs more testing if we can have frozen string literals
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Naming/MethodName:
+  Enabled: false
+
+Naming/VariableName:
+  Enabled: false
+
+Lint/Loop:
+  Enabled: false
+
+# Offense count: 24
+# Configuration parameters: CountComments, ExcludedMethods.
+# ExcludedMethods: refine
+Metrics/BlockLength:
+  Max: 350
+
+# Offense count: 5
+# Configuration parameters: CountBlocks.
+Metrics/BlockNesting:
+  Max: 4
+
+# Offense count: 12
+# Cop supports --auto-correct.
+# Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+# URISchemes: http, https
+Metrics/LineLength:
+  Max: 122
+
+# Offense count: 1
+# Configuration parameters: CountComments.
+Metrics/ModuleLength:
+  Max: 1400
+
+# Offense count: 2
+# Configuration parameters: CountKeywordArgs.
+Metrics/ParameterLists:
+  Max: 7
+
+# Offense count: 13
+Lint/UselessAssignment:
+  Exclude:
+    - 'src/clients/nis.rb'
+    - 'src/include/nis/ui.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 1
+Metrics/AbcSize:
+  Max: 339
+
+# Offense count: 1
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 908
+
+# Offense count: 1
+Metrics/CyclomaticComplexity:
+  Max: 57
+
+# Offense count: 1
+# Configuration parameters: CountComments, ExcludedMethods.
+Metrics/MethodLength:
+  Max: 369
+
+# Offense count: 1
+Metrics/PerceivedComplexity:
+  Max: 62
+
+# Offense count: 2
+# Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
+# AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
+Naming/FileName:
+  Exclude:
+    - 'src/clients/nis-client.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 1
+# Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.
+# NamePrefix: is_, has_, have_
+# NamePrefixBlacklist: is_, has_, have_
+# NameWhitelist: is_a?
+# MethodDefinitionMacros: define_method, define_singleton_method
+Naming/PredicateName:
+  Exclude:
+    - 'spec/**/*'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 3
+# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
+# AllowedNames: io, id, to, by, on, in, at, ip, db
+Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - 'src/include/nis/ui.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: Keywords.
+# Keywords: TODO, FIXME, OPTIMIZE, HACK, REVIEW
+Style/CommentAnnotation:
+  Exclude:
+    - 'src/clients/nis.rb'
+
+# Offense count: 1
+Style/CommentedKeyword:
+  Exclude:
+    - 'src/modules/Nis.rb'
+
+# Offense count: 6
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'src/clients/add-on.rb'
+    - 'src/clients/add-on_proposal.rb'
+    - 'src/clients/inst_add-on_software.rb'
+    - 'src/clients/vendor.rb'
+    - 'src/include/add-on/add-on-workflow.rb'
+    - 'src/include/add-on/misc.rb'
+    - 'src/lib/add-on/clients/add-on_auto.rb'
+    - 'src/modules/AddOnOthers.rb'
+    - 'src/clients/nis-client.rb'
+    - 'src/clients/nis.rb'
+    - 'src/clients/nis_auto.rb'
+    - 'src/include/nis/ui.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 3
+# Configuration parameters: MinBodyLength.
+Style/GuardClause:
+  Exclude:
+    - 'src/include/nis/ui.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 3
+Style/MultilineTernaryOperator:
+  Exclude:
+    - 'src/include/nis/ui.rb'
+    - 'src/modules/Nis.rb'
+
+# Offense count: 1
+Style/MultipleComparison:
+  Exclude:
+    - 'src/include/nis/ui.rb'
+
+# Offense count: 1
+Style/NestedTernaryOperator:
+  Exclude:
+    - 'src/include/nis/ui.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: IncludeSemanticChanges.
+Style/NonNilCheck:
+  Exclude:
+    - 'src/include/nis/ui.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  #lets ignore license check for now
+  # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -3,7 +3,8 @@ Thu Jun 11 11:29:59 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export any setting if ypbind is not installed
   (bsc#1172749).
-- Do not export nil settings (bsc#1172822).
+- Properly initialize NIS options when ypbind is not installed
+  (bsc#1172822).
 - 4.3.1
 
 -------------------------------------------------------------------

--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 11 11:29:59 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export any setting if ypbind is not installed
+  (bsc#1172749).
+- Do not export nil settings (bsc#1172822).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 14:02:35 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nis-client
 Summary:        YaST2 - Network Information Services (NIS, YP) Configuration
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 Group:          System/YaST

--- a/src/clients/nis-client.rb
+++ b/src/clients/nis-client.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
 #
@@ -19,8 +17,8 @@
 # current contact information at www.novell.com.
 # ------------------------------------------------------------------------------
 
-# Author:	Martin Vidner <mvidner@suse.cz>
-# Summary:	Just a redirection
+# Author:  Martin Vidner <mvidner@suse.cz>
+# Summary:  Just a redirection
 # $Id$
 module Yast
   class NisClientClient < Client

--- a/src/clients/nis.rb
+++ b/src/clients/nis.rb
@@ -149,8 +149,7 @@ module Yast
           }
         },
         "mappings"   =>
-                        # TODO:
-                        # more domains?
+                        # TODO: more domains?
                         # YPBIND_OPTIONS: delimiter??
                         {
                           "enable"    => ["server", "domain", "automounter", "broadcast"],
@@ -211,7 +210,7 @@ module Yast
     # @return [Boolean] true on success
     def NisEnableHandler(options)
       options = deep_copy(options)
-      ret = NisChangeConfiguration(options)
+      NisChangeConfiguration(options)
       Nis.start = true
       # if (Nis::GetDomain () == "" || Nis::GetServers () == "")
       # Nis::dhcp_wanted  = true;
@@ -221,8 +220,7 @@ module Yast
     # Disable the NIS client
     # @param [Hash] options  a list of parameters passed as args
     # @return [Boolean] true on success
-    def NisDisableHandler(options)
-      options = deep_copy(options)
+    def NisDisableHandler(_options)
       Nis.start = false
       true
     end
@@ -246,8 +244,7 @@ module Yast
 
     # Print summary of basic options
     # @return [Boolean] false
-    def NisSummaryHandler(options)
-      options = deep_copy(options)
+    def NisSummaryHandler(_options)
       CommandLine.Print(
         RichText.Rich2Plain(
           Ops.add(

--- a/src/clients/nis.rb
+++ b/src/clients/nis.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
 #
@@ -38,7 +36,7 @@
 # Modify: /etc/rc.config
 #
 
-#**
+# **
 # <h3>Configuration of the nis</h3>
 
 # @param flag "<b>screenshots</b>"<br>
@@ -62,8 +60,8 @@ module Yast
       @ret = :auto
 
       if !PackageSystem.CheckAndInstallPackagesInteractive(
-          Nis.required_packages
-        )
+        Nis.required_packages
+      )
         return deep_copy(@ret)
       end
 
@@ -100,7 +98,7 @@ module Yast
             )
           },
           "configure" => {
-            #FIXME "set" alias?
+            # FIXME: "set" alias?
             "handler" => fun_ref(
               method(:NisChangeConfiguration),
               "boolean (map)"
@@ -150,17 +148,17 @@ module Yast
             "typespec" => ["yes", "no"]
           }
         },
-        "mappings" =>
-          # TODO:
-          # more domains?
-          # YPBIND_OPTIONS: delimiter??
-          {
-            "enable"    => ["server", "domain", "automounter", "broadcast"],
-            "disable"   => [],
-            "summary"   => [],
-            "configure" => ["server", "domain", "automounter", "broadcast"],
-            "find"      => ["domain"]
-          }
+        "mappings"   =>
+                        # TODO:
+                        # more domains?
+                        # YPBIND_OPTIONS: delimiter??
+                        {
+                          "enable"    => ["server", "domain", "automounter", "broadcast"],
+                          "disable"   => [],
+                          "summary"   => [],
+                          "configure" => ["server", "domain", "automounter", "broadcast"],
+                          "find"      => ["domain"]
+                        }
       }
 
       @ret = CommandLine.Run(@cmdline)
@@ -208,7 +206,6 @@ module Yast
       ret
     end
 
-
     # Enable the NIS client
     # @param [Hash] options  a list of parameters passed as args
     # @return [Boolean] true on success
@@ -216,8 +213,8 @@ module Yast
       options = deep_copy(options)
       ret = NisChangeConfiguration(options)
       Nis.start = true
-      #if (Nis::GetDomain () == "" || Nis::GetServers () == "")
-      #Nis::dhcp_wanted	= true;
+      # if (Nis::GetDomain () == "" || Nis::GetServers () == "")
+      # Nis::dhcp_wanted  = true;
       true
     end
 
@@ -240,13 +237,12 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           SCR.Read(Builtins.add(path(".net.ypserv.find"), domain)),
-          :from => "any",
-          :to   => "list <string>"
+          from: "any",
+          to:   "list <string>"
         )
       ) { |server| CommandLine.Print(server) }
       false
     end
-
 
     # Print summary of basic options
     # @return [Boolean] false

--- a/src/clients/nis_auto.rb
+++ b/src/clients/nis_auto.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
 #
@@ -19,10 +17,10 @@
 # current contact information at www.novell.com.
 # ------------------------------------------------------------------------------
 
-# File:	clients/nis_auto.ycp
-# Package:	nis-client configuration
-# Summary:	client for autoinstallation
-# Authors:	Michal Svec <msvec@suse.cz>
+# File:  clients/nis_auto.ycp
+# Package:  nis-client configuration
+# Summary:  client for autoinstallation
+# Authors:  Michal Svec <msvec@suse.cz>
 #
 # $Id$
 module Yast
@@ -41,7 +39,6 @@ module Yast
       @ret = nil
       @func = ""
       @param = {}
-
 
       # Check arguments
       if Ops.greater_than(Builtins.size(WFM.Args), 0) &&
@@ -94,7 +91,7 @@ module Yast
       Builtins.y2milestone("NIS client autoinit client finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
       # EOF
     end
   end

--- a/src/include/nis/ui.rb
+++ b/src/include/nis/ui.rb
@@ -316,15 +316,8 @@ module Yast
       Builtins.y2debug("all_servers: %1", all_servers)
       Builtins.y2debug("additional_domains: %1", additional_domains)
 
-      automatic_label = NetworkService.is_network_manager ?
-        # radio button label
-        _("Au&tomatic Setup (Via NetworkManager and DHCP)") :
-        # radio button label
-        _("Au&tomatic Setup (via DHCP)")
-
       text_mode = Ops.get_boolean(UI.GetDisplayInfo, "TextMode", false)
 
-      con = nil
       # frame label
       nis_frame = Frame(
         _("NIS client"),
@@ -357,39 +350,7 @@ module Yast
               )
             ),
             VSpacing(0.2),
-            text_mode ?
-              HBox(
-                InputField(
-                  Id(:domain),
-                  Opt(:hstretch),
-                  _("N&IS Domain"),
-                  domain
-                ),
-                HSpacing(),
-                InputField(
-                  Id(:servers),
-                  Opt(:hstretch),
-                  _("&Addresses of NIS servers"),
-                  servers
-                )
-              ) :
-              VBox(
-                # text entry label
-                InputField(
-                  Id(:domain),
-                  Opt(:hstretch),
-                  _("N&IS Domain"),
-                  domain
-                ),
-                VSpacing(0.2),
-                InputField(
-                  Id(:servers),
-                  Opt(:hstretch),
-                  # text entry label
-                  _("&Addresses of NIS servers"),
-                  servers
-                )
-              ),
+            domain_and_servers(domain, servers, horizontal: text_mode),
             HBox(
               # check box label
               Left(
@@ -721,7 +682,6 @@ module Yast
       )
       Wizard.HideAbortButton
 
-      event = {}
       result = nil
       begin
         event = UI.WaitForEvent
@@ -1007,10 +967,6 @@ module Yast
 
       nis_vbox = VBox(VSpacing(0.2), multiple, VSpacing(0.2))
 
-      nis_frame =
-        # frame label
-        Frame(_("NIS client"), nis_vbox)
-
       contents = deep_copy(nis_vbox)
 
       Wizard.SetContentsButtons(
@@ -1127,9 +1083,6 @@ module Yast
           { d => Ops.get_list(v, 0, []) }
         end
         servers = Ops.get(only_servers, "", [])
-        default_broadcast = nil
-        multidomain_servers = nil
-        multidomain_broadcast = nil
 
         only_broadcast = Builtins.mapmap(all_servers) do |d, v|
           { d => Ops.get_boolean(v, 1, false) }
@@ -1257,6 +1210,18 @@ module Yast
       ret = Sequencer.Run(@Dialogs, @Sequence)
       UI.CloseDialog
       ret
+    end
+
+  private
+
+    def domain_and_servers(domain, servers, horizontal:)
+      widgets = [
+        InputField(Id(:domain), Opt(:hstretch), _("N&IS Domain"), domain),
+        horizontal ? HSpacing() : VSpacing(0.2),
+        InputField(Id(:servers), Opt(:hstretch), _("&Addresses of NIS servers"), servers)
+      ]
+
+      horizontal ? HBox(*widgets) : VBox(*widgets)
     end
   end
 end

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -745,7 +745,7 @@ module Yast
 
       Builtins.y2error("Attempt to export Nis::global_broadcast") if @global_broadcast
 
-      settings = {
+      {
         "start_nis"         => @start,
         "nis_servers"       => @servers,
         "nis_domain"        => @domain,
@@ -758,7 +758,6 @@ module Yast
         "slp_domain"        => @slp_domain,
         "netconfig_policy"  => @policy
       }
-      settings.reject { |_k, v| v.nil? }
     end
 
     # copied from Mail.ycp
@@ -911,9 +910,7 @@ module Yast
       @local_only = SCR.Read(path(".sysconfig.ypbind.YPBIND_LOCAL_ONLY")) == "yes"
       @global_broadcast = SCR.Read(path(".sysconfig.ypbind.YPBIND_BROADCAST")) == "yes"
       @broken_server = SCR.Read(path(".sysconfig.ypbind.YPBIND_BROKEN_SERVER")) == "yes"
-      @options = Convert.to_string(
-        SCR.Read(path(".sysconfig.ypbind.YPBIND_OPTIONS"))
-      )
+      @options = SCR.Read(path(".sysconfig.ypbind.YPBIND_OPTIONS")).to_s
 
       # install on demand
       @_start_autofs = @_autofs_allowed && Service.Enabled("autofs")

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -779,13 +779,10 @@ module Yast
           Ops.greater_than(Builtins.size(Convert.to_list(value)), 0)
         summary = Summary.OpenList(summary)
         Builtins.foreach(Convert.to_list(value)) do |d|
-          entry = ""
           entry = if Ops.is_map?(d) || Ops.is_list?(d)
             Builtins.sformat(
               "%1 Entries configured",
-              Ops.is_map?(d) ?
-                Builtins.size(Convert.to_map(value)) :
-                Builtins.size(Convert.to_list(value))
+              Ops.is_map?(d) ? Builtins.size(Convert.to_map(value)) : Builtins.size(Convert.to_list(value))
             )
           else
             Convert.to_string(d)
@@ -806,12 +803,6 @@ module Yast
       # too complicated to write by hand?
       summary = ""
       nc = Summary.NotConfigured
-
-      # summary: Domain or servers are retrieved by the
-      # Dynamic Host Configuration Protocol.
-      # Will be placed after NIS Domain/NIS Servers instead of the
-      # actual settings.
-      dhcp = _("by DHCP")
 
       # summary header
       summary = Summary.AddHeader(summary, _("NIS Client enabled"))
@@ -867,7 +858,6 @@ module Yast
     # It is called by "authentication/user sources" dialog in yast2-users
     # @return summary of the current configuration
     def ShortSummary
-      summary = ""
       nc = Summary.NotConfigured
       summary = Ops.add(
         Ops.add(
@@ -1089,7 +1079,7 @@ module Yast
           end
 
           Nsswitch.WriteDb(db, db_l)
-        end # not start
+        end
       else
         Builtins.y2milestone("not writing pluses")
 

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
 #
@@ -126,7 +124,6 @@ module Yast
       # interface and remote hosts cannot query it.
       @local_only = false
 
-
       # You should set this to "yes" if you have a NIS server in your
       # network, which binds only to high ports over 1024. Since this
       # is a security risk, you should consider to replace the NIS
@@ -212,20 +209,21 @@ module Yast
         SCR.Read(path(".sysconfig.network.config.NETCONFIG_NIS_POLICY"))
       )
       Builtins.y2milestone("policy : %1", @policy)
-      @policy = "" if @policy == nil
+      @policy = "" if @policy.nil?
 
       staticVals = {}
       keylist = SCR.Dir(path(".sysconfig.network.config"))
 
       Builtins.y2milestone("KEYLIST: %1", keylist)
 
-      keylist = [] if keylist == nil
+      keylist = [] if keylist.nil?
 
       Builtins.foreach(keylist) do |key|
         if !Builtins.issubstring(key, "NETCONFIG_NIS_STATIC_DOMAIN") &&
             !Builtins.issubstring(key, "NETCONFIG_NIS_STATIC_SERVERS")
           next
         end
+
         value = Convert.to_string(
           SCR.Read(Builtins.add(path(".sysconfig.network.config"), key))
         )
@@ -296,24 +294,18 @@ module Yast
         end
       end
 
-      Builtins.foreach(@multidomain_servers) do |domain, value|
-        if !Builtins.haskey(@multidomain_broadcast, domain)
-          Ops.set(@multidomain_broadcast, domain, false)
-        end
+      Builtins.foreach(@multidomain_servers) do |domain, _value|
+        Ops.set(@multidomain_broadcast, domain, false) if !Builtins.haskey(@multidomain_broadcast, domain)
       end
 
-      Builtins.foreach(@multidomain_broadcast) do |domain, value|
-        if !Builtins.haskey(@multidomain_servers, domain)
-          Ops.set(@multidomain_servers, domain, [])
-        end
+      Builtins.foreach(@multidomain_broadcast) do |domain, _value|
+        Ops.set(@multidomain_servers, domain, []) if !Builtins.haskey(@multidomain_servers, domain)
       end
 
       Builtins.foreach(
-        Convert.convert(@slp_domain, :from => "map", :to => "map <string, any>")
-      ) do |domain, value|
-        if !Builtins.haskey(@multidomain_servers, domain)
-          Ops.set(@multidomain_servers, domain, [])
-        end
+        Convert.convert(@slp_domain, from: "map", to: "map <string, any>")
+      ) do |domain, _value|
+        Ops.set(@multidomain_servers, domain, []) if !Builtins.haskey(@multidomain_servers, domain)
       end
 
       Builtins.y2milestone("Servers: %1", @servers)
@@ -329,24 +321,18 @@ module Yast
     def setNetconfigValues
       SCR.Write(path(".sysconfig.network.config.NETCONFIG_NIS_POLICY"), @policy)
 
-      Builtins.foreach(@multidomain_servers) do |domain, value|
-        if !Builtins.haskey(@multidomain_broadcast, domain)
-          Ops.set(@multidomain_broadcast, domain, false)
-        end
+      Builtins.foreach(@multidomain_servers) do |domain, _value|
+        Ops.set(@multidomain_broadcast, domain, false) if !Builtins.haskey(@multidomain_broadcast, domain)
       end
 
-      Builtins.foreach(@multidomain_broadcast) do |domain, value|
-        if !Builtins.haskey(@multidomain_servers, domain)
-          Ops.set(@multidomain_servers, domain, [])
-        end
+      Builtins.foreach(@multidomain_broadcast) do |domain, _value|
+        Ops.set(@multidomain_servers, domain, []) if !Builtins.haskey(@multidomain_servers, domain)
       end
 
       Builtins.foreach(
-        Convert.convert(@slp_domain, :from => "map", :to => "map <string, any>")
-      ) do |domain, value|
-        if !Builtins.haskey(@multidomain_servers, domain)
-          Ops.set(@multidomain_servers, domain, [])
-        end
+        Convert.convert(@slp_domain, from: "map", to: "map <string, any>")
+      ) do |domain, _value|
+        Ops.set(@multidomain_servers, domain, []) if !Builtins.haskey(@multidomain_servers, domain)
       end
 
       Builtins.foreach(@static_keylist) do |key|
@@ -363,7 +349,6 @@ module Yast
         path(".sysconfig.network.config.NETCONFIG_NIS_STATIC_SERVERS"),
         ""
       )
-
 
       Builtins.y2milestone("Servers: %1", @servers)
       Builtins.y2milestone("multidomain_servers: %1", @multidomain_servers)
@@ -387,11 +372,12 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           @multidomain_servers,
-          :from => "map <string, list>",
-          :to   => "map <string, list <string>>"
+          from: "map <string, list>",
+          to:   "map <string, list <string>>"
         )
       ) do |dom, srvs|
         next if dom == ""
+
         if Ops.greater_than(Builtins.size(srvs), 0)
           if cnt == 0
             SCR.Write(
@@ -566,8 +552,8 @@ module Yast
     # used also for nis-server
 
     # Check syntax of a NIS domain name
-    # @param [String] domain	a domain name
-    # @return		true if correct
+    # @param [String] domain  a domain name
+    # @return    true if correct
     def check_nisdomainname(domain)
       # TODO
       # disallow whitespace and special characters...
@@ -579,8 +565,8 @@ module Yast
     def valid_nisdomainname
       # Translators: do not translate (none)!
       _(
-        "A NIS domain name must not be empty,\n" +
-          "it must not be \"(none)\",\n" +
+        "A NIS domain name must not be empty,\n" \
+          "it must not be \"(none)\",\n" \
           "and it must be at most 64 characters long.\n"
       )
     end
@@ -599,8 +585,8 @@ module Yast
         # message popup
         return Ops.add(
           _(
-            "Only an IP address can be used\n" +
-              "because host names are resolved using NIS.\n" +
+            "Only an IP address can be used\n" \
+              "because host names are resolved using NIS.\n" \
               "\n"
           ),
           IP.Valid4
@@ -624,10 +610,10 @@ module Yast
     end
 
     # A convenient shortcut for setting touched.
-    # @param [Boolean] really	if true, set Nis::touched
+    # @param [Boolean] really  if true, set Nis::touched
     # @example Nis::Touch (Nis::var != ui_var);
     def Touch(really)
-      @touched = @touched || really
+      @touched ||= really
 
       nil
     end
@@ -648,9 +634,7 @@ module Yast
             _("The automounter package will be installed.\n")
           )
         end
-        if !Package.Installed("nfs-client")
-          @install_packages = Builtins.add(@install_packages, "nfs-client")
-        end
+        @install_packages = Builtins.add(@install_packages, "nfs-client") if !Package.Installed("nfs-client")
       end
 
       message
@@ -691,8 +675,8 @@ module Yast
       if @_start_autofs
         @required_packages = Convert.convert(
           Builtins.union(@required_packages, ["autofs", "nfs-client"]),
-          :from => "list",
-          :to   => "list <string>"
+          from: "list",
+          to:   "list <string>"
         )
       end
 
@@ -704,18 +688,18 @@ module Yast
       nil
     end
 
-    # TODO update the map keys
+    # TODO: update the map keys
     # better still: link to a current interface description
     # Get all the NIS configuration from a map.
     # When called by nis_auto (preparing autoinstallation data)
     # the map may be empty.
-    # @param [Hash] settings	$["start": "domain": "servers":[...] ]
-    # @return	success
+    # @param [Hash] settings  $["start": "domain": "servers":[...] ]
+    # @return  success
     def Import(settings)
       settings = deep_copy(settings)
       if Builtins.size(settings) == 0
-        #Provide defaults for autoinstallation editing:
-        #Leave empty.
+        # Provide defaults for autoinstallation editing:
+        # Leave empty.
         @old_domain = @domain
         # enable _autofs_allowed
         # Injecting it into the defaults for the GUI
@@ -741,7 +725,7 @@ module Yast
       true
     end
 
-    # TODO update the map keys
+    # TODO: update the map keys
     # better still: link to a current interface description
     # Dump the NIS settings to a map, for autoinstallation use.
     # @return $["start":, "servers":[...], "domain":]
@@ -754,9 +738,7 @@ module Yast
         }
       end
 
-      if @global_broadcast
-        Builtins.y2error("Attempt to export Nis::global_broadcast")
-      end
+      Builtins.y2error("Attempt to export Nis::global_broadcast") if @global_broadcast
 
       {
         "start_nis"         => @start,
@@ -783,25 +765,25 @@ module Yast
       value = deep_copy(value)
       summary = ""
       summary = Summary.AddHeader(summary, title)
-      #enhancement BEGIN
-      value = Builtins.maplist(Convert.to_map(value)) { |k, v| k } if Ops.is_map?(
+      # enhancement BEGIN
+      value = Builtins.maplist(Convert.to_map(value)) { |k, _v| k } if Ops.is_map?(
         value
       )
-      #enhancement END
+      # enhancement END
       if Ops.is_list?(value) &&
           Ops.greater_than(Builtins.size(Convert.to_list(value)), 0)
         summary = Summary.OpenList(summary)
         Builtins.foreach(Convert.to_list(value)) do |d|
           entry = ""
-          if Ops.is_map?(d) || Ops.is_list?(d)
-            entry = Builtins.sformat(
+          entry = if Ops.is_map?(d) || Ops.is_list?(d)
+            Builtins.sformat(
               "%1 Entries configured",
               Ops.is_map?(d) ?
                 Builtins.size(Convert.to_map(value)) :
                 Builtins.size(Convert.to_list(value))
             )
           else
-            entry = Convert.to_string(d)
+            Convert.to_string(d)
           end
           summary = Summary.AddListItem(summary, entry)
         end
@@ -814,7 +796,7 @@ module Yast
 
     # @return Html formatted configuration summary
     def Summary
-      # TODO multidomain_servers, multidomain_broadcast
+      # TODO: multidomain_servers, multidomain_broadcast
       # OK, a dumb mapping is possible, but wouldn't it be
       # too complicated to write by hand?
       summary = ""
@@ -832,12 +814,12 @@ module Yast
       summary = Summary.AddLine(summary, @start ? _("Yes") : nc)
       # summary header
       summary = Summary.AddHeader(summary, _("NIS Domain"))
-      summary = Summary.AddLine(summary, @domain != "" ? @domain : nc)
+      summary = Summary.AddLine(summary, (@domain != "") ? @domain : nc)
       # summary header
       summary = Summary.AddHeader(summary, _("NIS Servers"))
       summary = Summary.AddLine(
         summary,
-        @servers != [] ? Builtins.mergestring(@servers, "<br>") : nc
+        (@servers != []) ? Builtins.mergestring(@servers, "<br>") : nc
       )
       # summary header
       summary = Summary.AddHeader(summary, _("Broadcast"))
@@ -858,7 +840,7 @@ module Yast
       summary = Summary.AddLine(summary, @broken_server ? _("Yes") : nc)
       # summary header
       summary = Summary.AddHeader(summary, _("ypbind options"))
-      summary = Summary.AddLine(summary, @options != "" ? @options : nc)
+      summary = Summary.AddLine(summary, (@options != "") ? @options : nc)
       # summary header
       summary = Summary.AddHeader(summary, _("Automounter enabled"))
       # summary item: an option is turned on
@@ -885,9 +867,9 @@ module Yast
       summary = Ops.add(
         Ops.add(
           # summary item
-          BrItem(_("Servers"), @servers != [] ? GetServers() : nc),
+          BrItem(_("Servers"), (@servers != []) ? GetServers() : nc),
           # summary item
-          BrItem(_("Domain"), @domain != "" ? @domain : nc)
+          BrItem(_("Domain"), (@domain != "") ? @domain : nc)
         ),
         # summary item (yes/no follows)
         BrItem(_("Client Enabled"), @start ? _("Yes") : _("No"))
@@ -903,17 +885,15 @@ module Yast
 
       getNetconfigValues
 
-      @servers = [] if @servers == nil
-      @default_broadcast = false if @default_broadcast == nil
-      @multidomain_servers = {} if @multidomain_servers == nil
-      @multidomain_broadcast = {} if @multidomain_broadcast == nil
-      @slp_domain = {} if @slp_domain == nil
+      @servers = [] if @servers.nil?
+      @default_broadcast = false if @default_broadcast.nil?
+      @multidomain_servers = {} if @multidomain_servers.nil?
+      @multidomain_broadcast = {} if @multidomain_broadcast.nil?
+      @slp_domain = {} if @slp_domain.nil?
 
       out = SCR.Execute(path(".target.bash_output"), "/usr/bin/ypdomainname")
       # 0 OK, 1 mean no domain name set, so no nis, do not report it
-      if out["exit"] > 1
-        Report.Error(_("Getting domain name via ypdomainname failed with '%s'") % out["stderr"])
-      end
+      Report.Error(_("Getting domain name via ypdomainname failed with '%s'") % out["stderr"]) if out["exit"] > 1
       @domain = out["stdout"].chomp
       @old_domain = @domain
 
@@ -987,8 +967,8 @@ module Yast
     end
 
     # If a file does not contain a NIS entry, add it.
-    # @param [String] file	pathname
-    # @param [String] what	a "+" line without a '\n'
+    # @param [String] file  pathname
+    # @param [String] what  a "+" line without a '\n'
     # @return success?
     def WritePlusesTo(file, what)
       ok = true
@@ -999,17 +979,17 @@ module Yast
           Builtins.sformat("/usr/bin/cp %1 %1.YaST2save", file.shellescape)
         )
         if SCR.Execute(
-            path(".target.bash"),
-            Builtins.sformat("/usr/bin/echo %1 >> %2", what.shellescape, file.shellescape)
-          ) != 0
+          path(".target.bash"),
+          Builtins.sformat("/usr/bin/echo %1 >> %2", what.shellescape, file.shellescape)
+        ) != 0
           ok = false
         end
-      # TODO only for passwd?
+      # TODO: only for passwd?
       # replace the 'nologin' occurence (#40571)
       elsif SCR.Execute(
-          path(".target.bash"),
-          Builtins.sformat("/usr/bin/grep -q ^%1/sbin/nologin %2", what.shellescape, file.shellescape)
-        ) == 0
+        path(".target.bash"),
+        Builtins.sformat("/usr/bin/grep -q ^%1/sbin/nologin %2", what.shellescape, file.shellescape)
+      ) == 0
         ok = SCR.Execute(
           path(".target.bash"),
           Builtins.sformat(
@@ -1036,7 +1016,7 @@ module Yast
     # @return success?
     def WritePluses
       files = ["passwd", "shadow", "group"]
-      #don't forget a newline
+      # don't forget a newline
       what_to_write = {
         "passwd" => "+::::::",
         "group"  => "+:::",
@@ -1045,9 +1025,9 @@ module Yast
       Builtins.foreach(files) do |f|
         Builtins.y2milestone("Writing pluses to %1", f)
         if !WritePlusesTo(
-            Builtins.sformat("/etc/%1", f),
-            Ops.get_string(what_to_write, f, "")
-          )
+          Builtins.sformat("/etc/%1", f),
+          Ops.get_string(what_to_write, f, "")
+        )
           next false
         end
       end
@@ -1097,15 +1077,15 @@ module Yast
         nis_dbs.each do |db|
           db_l = Nsswitch.ReadDb(db)
 
-          if !db_l.include?("nis")
-            if db == "netgroup"
-              db_l = ["nis"]
-            else
-              db_l << "nis"
-            end
+          next if db_l.include?("nis")
 
-            Nsswitch.WriteDb(db, db_l)
+          if db == "netgroup"
+            db_l = ["nis"]
+          else
+            db_l << "nis"
           end
+
+          Nsswitch.WriteDb(db, db_l)
         end # not start
       else
         Builtins.y2milestone("not writing pluses")
@@ -1144,10 +1124,10 @@ module Yast
     # @return true on success
     def WriteOnly
       if @start
-        if Package.Installed("rpcbind")
-          @rpc_mapper = "rpcbind"
+        @rpc_mapper = if Package.Installed("rpcbind")
+          "rpcbind"
         else
-          @rpc_mapper = "portmap"
+          "portmap"
         end
 
         Service.Enable(@rpc_mapper)
@@ -1185,7 +1165,7 @@ module Yast
 
         SCR.Write(
           path(".sysconfig.network.config.NETCONFIG_NIS_SETDOMAINNAME"),
-          @policy == "" ? "no" : "yes"
+          (@policy == "") ? "no" : "yes"
         )
 
         if !SCR.Write(path(".sysconfig.network.dhcp"), nil)
@@ -1197,7 +1177,7 @@ module Yast
         Service.Disable("ypbind")
       end
 
-      # TODO do as much as possible if one thing fails
+      # TODO: do as much as possible if one thing fails
       # especially WRT nis/autofs independence
       WriteNssConf()
 
@@ -1323,54 +1303,54 @@ module Yast
       { "install" => install_pkgs, "remove" => remove_pkgs }
     end
 
-    publish :variable => :modified, :type => "boolean"
-    publish :function => :SetModified, :type => "void ()"
-    publish :function => :GetModified, :type => "boolean ()"
-    publish :variable => :required_packages, :type => "list <string>"
-    publish :variable => :start, :type => "boolean"
-    publish :variable => :servers, :type => "list <string>"
-    publish :function => :GetServers, :type => "string ()"
-    publish :function => :SetServers, :type => "void (string)"
-    publish :variable => :default_broadcast, :type => "boolean"
-    publish :variable => :multidomain_servers, :type => "map <string, list>"
-    publish :variable => :multidomain_broadcast, :type => "map <string, boolean>"
-    publish :variable => :global_broadcast, :type => "boolean"
-    publish :variable => :slp_domain, :type => "map"
-    publish :variable => :policy, :type => "string"
-    publish :function => :getNetconfigValues, :type => "void ()"
-    publish :function => :setNetconfigValues, :type => "boolean ()"
-    publish :function => :DomainChanged, :type => "boolean ()"
-    publish :function => :GetDomain, :type => "string ()"
-    publish :function => :SetDomain, :type => "void (string)"
-    publish :variable => :dhcpcd_running, :type => "boolean"
-    publish :variable => :dhcp_restart, :type => "boolean"
-    publish :variable => :local_only, :type => "boolean"
-    publish :variable => :broken_server, :type => "boolean"
-    publish :variable => :options, :type => "string"
-    publish :variable => :_autofs_allowed, :type => "boolean"
-    publish :variable => :_start_autofs, :type => "boolean"
-    publish :variable => :YpbindErrors, :type => "string"
-    publish :function => :check_nisdomainname, :type => "boolean (string)"
-    publish :function => :valid_nisdomainname, :type => "string ()"
-    publish :function => :UsersByLdap, :type => "boolean ()"
-    publish :function => :valid_address_nis, :type => "string ()"
-    publish :function => :check_address_nis, :type => "boolean (string)"
-    publish :variable => :touched, :type => "boolean"
-    publish :function => :Touch, :type => "void (boolean)"
-    publish :variable => :install_packages, :type => "list <string>"
-    publish :function => :ProbePackages, :type => "string ()"
-    publish :function => :Set, :type => "void (map)"
-    publish :function => :Import, :type => "boolean (map)"
-    publish :function => :Export, :type => "map ()"
-    publish :function => :Summary, :type => "string ()"
-    publish :function => :BrItem, :type => "string (string, string)"
-    publish :function => :ShortSummary, :type => "string ()"
-    publish :function => :Read, :type => "boolean ()"
-    publish :function => :Fake, :type => "void ()"
-    publish :function => :WriteNssConf, :type => "boolean ()"
-    publish :function => :WriteOnly, :type => "boolean ()"
-    publish :function => :Write, :type => "boolean ()"
-    publish :function => :AutoPackages, :type => "map ()"
+    publish variable: :modified, type: "boolean"
+    publish function: :SetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
+    publish variable: :required_packages, type: "list <string>"
+    publish variable: :start, type: "boolean"
+    publish variable: :servers, type: "list <string>"
+    publish function: :GetServers, type: "string ()"
+    publish function: :SetServers, type: "void (string)"
+    publish variable: :default_broadcast, type: "boolean"
+    publish variable: :multidomain_servers, type: "map <string, list>"
+    publish variable: :multidomain_broadcast, type: "map <string, boolean>"
+    publish variable: :global_broadcast, type: "boolean"
+    publish variable: :slp_domain, type: "map"
+    publish variable: :policy, type: "string"
+    publish function: :getNetconfigValues, type: "void ()"
+    publish function: :setNetconfigValues, type: "boolean ()"
+    publish function: :DomainChanged, type: "boolean ()"
+    publish function: :GetDomain, type: "string ()"
+    publish function: :SetDomain, type: "void (string)"
+    publish variable: :dhcpcd_running, type: "boolean"
+    publish variable: :dhcp_restart, type: "boolean"
+    publish variable: :local_only, type: "boolean"
+    publish variable: :broken_server, type: "boolean"
+    publish variable: :options, type: "string"
+    publish variable: :_autofs_allowed, type: "boolean"
+    publish variable: :_start_autofs, type: "boolean"
+    publish variable: :YpbindErrors, type: "string"
+    publish function: :check_nisdomainname, type: "boolean (string)"
+    publish function: :valid_nisdomainname, type: "string ()"
+    publish function: :UsersByLdap, type: "boolean ()"
+    publish function: :valid_address_nis, type: "string ()"
+    publish function: :check_address_nis, type: "boolean (string)"
+    publish variable: :touched, type: "boolean"
+    publish function: :Touch, type: "void (boolean)"
+    publish variable: :install_packages, type: "list <string>"
+    publish function: :ProbePackages, type: "string ()"
+    publish function: :Set, type: "void (map)"
+    publish function: :Import, type: "boolean (map)"
+    publish function: :Export, type: "map ()"
+    publish function: :Summary, type: "string ()"
+    publish function: :BrItem, type: "string (string, string)"
+    publish function: :ShortSummary, type: "string ()"
+    publish function: :Read, type: "boolean ()"
+    publish function: :Fake, type: "void ()"
+    publish function: :WriteNssConf, type: "boolean ()"
+    publish function: :WriteOnly, type: "boolean ()"
+    publish function: :Write, type: "boolean ()"
+    publish function: :AutoPackages, type: "map ()"
   end
 
   Nis = NisClass.new

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -36,6 +36,7 @@
 require "yast"
 require "y2firewall/firewalld"
 require "shellwords"
+Yast.import "Mode"
 
 module Yast
   class NisClass < Module
@@ -733,7 +734,7 @@ module Yast
     # Dump the NIS settings to a map, for autoinstallation use.
     # @return $["start":, "servers":[...], "domain":]
     def Export
-      return {} unless Yast::Package.Installed(NIS_CLIENT_PACKAGE)
+      return {} unless Yast::Mode.config || Yast::Package.Installed(NIS_CLIENT_PACKAGE)
 
       other_domains = Builtins.maplist(@multidomain_servers) do |d, s|
         {

--- a/test/nis_test.rb
+++ b/test/nis_test.rb
@@ -53,28 +53,32 @@ describe Yast::Nis do
     end
 
     it "reads local_only flag" do
-      expect(Yast::SCR).to receive(:Read).with(path(".sysconfig.ypbind.YPBIND_LOCAL_ONLY")).and_return("yes")
+      expect(Yast::SCR).to receive(:Read)
+        .with(path(".sysconfig.ypbind.YPBIND_LOCAL_ONLY")).and_return("yes")
 
       subject.Read
       expect(subject.local_only).to eq true
     end
 
     it "reads global_broadcast flag" do
-      expect(Yast::SCR).to receive(:Read).with(path(".sysconfig.ypbind.YPBIND_BROADCAST")).and_return("yes")
+      expect(Yast::SCR).to receive(:Read)
+        .with(path(".sysconfig.ypbind.YPBIND_BROADCAST")).and_return("yes")
 
       subject.Read
       expect(subject.global_broadcast).to eq true
     end
 
     it "reads broken_server flag" do
-      expect(Yast::SCR).to receive(:Read).with(path(".sysconfig.ypbind.YPBIND_BROKEN_SERVER")).and_return("yes")
+      expect(Yast::SCR).to receive(:Read)
+        .with(path(".sysconfig.ypbind.YPBIND_BROKEN_SERVER")).and_return("yes")
 
       subject.Read
       expect(subject.broken_server).to eq true
     end
 
     it "reads options" do
-      expect(Yast::SCR).to receive(:Read).with(path(".sysconfig.ypbind.YPBIND_OPTIONS")).and_return("yohoho")
+      expect(Yast::SCR).to receive(:Read)
+        .with(path(".sysconfig.ypbind.YPBIND_OPTIONS")).and_return("yohoho")
 
       subject.Read
       expect(subject.options).to eq "yohoho"

--- a/test/nis_test.rb
+++ b/test/nis_test.rb
@@ -158,9 +158,11 @@ describe Yast::Nis do
 
   describe "#Export" do
     let(:ypbind_installed) { true }
+    let(:config_mode) { false }
 
     before do
       allow(Yast::Package).to receive(:Installed).with("ypbind").and_return(ypbind_installed)
+      allow(Yast::Mode).to receive(:config).and_return(config_mode)
       subject.Import(
         "start_nis"   => true,
         "nis_servers" => ["nis.example.net"]
@@ -177,8 +179,20 @@ describe Yast::Nis do
     context "when the ypbind package is not installed" do
       let(:ypbind_installed) { false }
 
-      it "exports an empty hash" do
-        expect(subject.Export).to eq({})
+      context "during config mode" do
+        let(:config_mode) { true }
+
+        it "returns the module settings" do
+          expect(subject.Export).to_not be_empty
+        end
+      end
+
+      context "during not config mode" do
+        let(:config_mode) { false }
+
+        it "returns an empty hash" do
+          expect(subject.Export).to eq({})
+        end
       end
     end
   end

--- a/test/nis_test.rb
+++ b/test/nis_test.rb
@@ -143,4 +143,42 @@ describe Yast::Nis do
       subject.Write
     end
   end
+
+  describe "#Export" do
+    let(:ypbind_installed) { true }
+    let(:nis_options) { "-verbose" }
+
+    before do
+      allow(Yast::Package).to receive(:Installed).with("ypbind").and_return(ypbind_installed)
+      subject.Import(
+        "start_nis"   => true,
+        "nis_servers" => ["nis.example.net"],
+        "nis_options" => nis_options
+      )
+    end
+
+    it "returns module settings" do
+      expect(subject.Export).to include(
+        "start_nis"   => subject.start,
+        "nis_servers" => subject.servers,
+        "nis_options" => nis_options
+      )
+    end
+
+    context "when some value is nil" do
+      let(:nis_options) { nil }
+
+      it "does not include the nil value" do
+        expect(subject.Export.keys).to_not include("nis_options")
+      end
+    end
+
+    context "when the ypbind package is not installed" do
+      let(:ypbind_installed) { false }
+
+      it "exports an empty hash" do
+        expect(subject.Export).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR implements these changes:

* Do not export nil values (fix for [bsc#1172822](https://bugzilla.suse.com/show_bug.cgi?id=1172822)).
* Do no export any setting if ypbind is not even installed ([bsc#1172749](https://bugzilla.opensuse.org/show_bug.cgi?id=1172749)).