### PR TITLE
Use yast2-pam/Nsswitch module to save the NSS configuration 

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 24 14:19:42 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Properly save the NSS configuration (related to bsc#1173119).
+- 4.3.2
+
+-------------------------------------------------------------------
 Thu Jun 11 11:29:59 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export any setting if ypbind is not installed

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nis-client
 Summary:        YaST2 - Network Information Services (NIS, YP) Configuration
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 Group:          System/YaST

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -28,7 +28,9 @@ Source0:        %{name}-%{version}.tar.bz2
 
 # SuSEfirewall2_* services merged into one service yast2-2.23.17
 BuildRequires:  yast2 >= 2.23.17
-BuildRequires:  gcc-c++ doxygen yast2-core-devel yast2-pam update-desktop-files libtool
+BuildRequires:  gcc-c++ doxygen yast2-core-devel update-desktop-files libtool
+# Nsswitch#Write
+BuildRequires:  yast2-pam >= 4.3.0
 BuildRequires:  libnsl-devel
 BuildRequires:  libtirpc-devel
 BuildRequires:  yast2-devtools >= 4.2.2
@@ -36,7 +38,9 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
 # Wizard::SetDesktopTitleAndIcon
 Requires:       yast2 >= 2.21.22
-Requires:       yast2-pam yast2-network
+Requires:       yast2-network
+# Nsswitch#Write
+Requires:       yast2-pam >= 4.3.0
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yp-tools
 

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -1107,11 +1107,7 @@ module Yast
         end
       end
 
-      return true if SCR.Write(path(".etc.nsswitch_conf"), nil)
-
-      Report.Error(Message.ErrorWritingFile("/etc/nsswitch.conf"))
-
-      false
+      Nsswitch.Write
     end
 
     # Only write new configuration w/o starting any scripts

--- a/test/nis_test.rb
+++ b/test/nis_test.rb
@@ -19,6 +19,7 @@ describe Yast::Nis do
     allow(Yast::Service).to receive(:Status).and_return(0)
     allow(Y2Firewall::Firewalld.instance).to receive(:read)
     allow(Yast::Autologin).to receive(:Read)
+    allow(Yast::Nsswitch).to receive(:Write).and_return(true)
     allow(Yast::Nsswitch).to receive(:ReadDb).and_return([])
     allow(Yast::Package).to receive(:Installed).and_return(true)
 


### PR DESCRIPTION
## Problem

The old SCR nsswitch agent has been replaced by a CFA class able to deal with the new layout having the configuration split between `/usr/etc` and `/etc.` See https://github.com/yast/yast-pam/pull/20 for more details.

## Solution

Use [yast2-pam/Nsswitch module](https://github.com/yast/yast-pam/blob/43201e3ed0d50f8dce3a853aef3057265d8aa471/src/modules/Nsswitch.rb) to save the NSS changes instead of the no longer available SCR agent.