### PR TITLE
Fix broken logic to enforce compat (bug#1174603)

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 12:49:27 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed the mechanism used to ensure the usage of "compat" for
+  certain databases (bsc#1174603).
+- 4.2.4
+
+-------------------------------------------------------------------
 Mon Feb 24 14:12:47 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fixed crash caused by previous fix (bsc#1164699)

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nis-client
 Summary:        YaST2 - Network Information Services (NIS, YP) Configuration
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Url:            https://github.com/yast/yast-nis-client
 Group:          System/YaST

--- a/src/modules/Nis.rb
+++ b/src/modules/Nis.rb
@@ -1074,7 +1074,7 @@ module Yast
           # We get [] meaning compat, so it's ok to make it explicit
           db_l = Nsswitch.ReadDb(db)
 
-          if db_l.include?("compat")
+          if !db_l.include?("compat")
             # remove "files" and "nis", if there;
             db_l -= ["files", "nis"]
 


### PR DESCRIPTION
## Problem

During the implementation of yast2-nis-client 4.2.2, one condition got inverted by mistake. See https://github.com/yast/yast-nis-client/pull/44/files#r461469282

Before the change, YaST used to ensure "compat" was the first service (removing "nis" and "files" in the process) for the following databases: "passwd", "group", "shadow".

After the change it just adds "compat" to those databases... if it's already there! So the affected databases end up containing "compat" twice, which is clearly an error.

See https://bugzilla.suse.com/show_bug.cgi?id=1174603

## Solution

Simply restore the original condition.