### PR TITLE
Add missing BuildRequires for SLE-15-SP2

### DIFF
--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -32,6 +32,7 @@ BuildRequires:  gcc-c++ perl-XML-Writer doxygen yast2-core-devel yast2-testsuite
 BuildRequires:  libnsl-devel
 BuildRequires:  libtirpc-devel
 BuildRequires:  yast2-devtools >= 4.2.2
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 
 # Wizard::SetDesktopTitleAndIcon
 Requires:       yast2 >= 2.21.22


### PR DESCRIPTION
`rake osc:build` doesn't work in the SLE-15-SP2 branch. This fixes it for me.