### PR TITLE
Fixed testsuite failure during RPM build (bsc#1195194)

### DIFF
--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 27 10:31:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed testsuite failure during RPM build (bsc#1195194)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-nis-client.spec
+++ b/package/yast2-nis-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nis-client
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Network Information Services (NIS, YP) Configuration
 License:        GPL-2.0-only

--- a/test/nis_test.rb
+++ b/test/nis_test.rb
@@ -20,6 +20,7 @@ describe Yast::Nis do
     allow(Yast::Service).to receive(:Disable).and_return(true)
     allow(Yast::Service).to receive(:Status).and_return(0)
     allow(Y2Firewall::Firewalld.instance).to receive(:read)
+    allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
     allow(Yast::Autologin).to receive(:Read)
     allow(Yast::Nsswitch).to receive(:Write).and_return(true)
     allow(Yast::Nsswitch).to receive(:ReadDb).and_return([])


### PR DESCRIPTION
Fixes this problem during RPM build:

```
[   50s]   1) #<Yast::NisClass:0x000055f6888588e0> #Write calls WriteOnly
[   50s]      Failure/Error: subject.Write
[   50s] 
[   50s]      RuntimeError:
[   50s]        Failed to open dialog, see logs.
[   50s]      # /usr/share/YaST2/lib/yast2/popup.rb:235:in `event_loop'
[   50s]      # /usr/share/YaST2/lib/yast2/popup.rb:90:in `show'
[   50s]      # /usr/share/YaST2/modules/Report.rb:562:in `Error'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:232:in `rescue in popup_error'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:227:in `popup_error'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:179:in `run'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:130:in `run_or_chain'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:85:in `on_target!'
[   50s]      # /usr/share/YaST2/lib/yast2/execute.rb:72:in `on_target'
[   50s]      # /usr/share/YaST2/lib/y2firewall/firewalld/api.rb:115:in `state'
[   50s]      # /usr/share/YaST2/lib/y2firewall/firewalld/api.rb:96:in `running?'
[   50s]      # /usr/share/YaST2/lib/y2firewall/firewalld/api.rb:68:in `initialize'
[   50s]      # /usr/share/YaST2/lib/y2firewall/firewalld.rb:260:in `new'
[   50s]      # /usr/share/YaST2/lib/y2firewall/firewalld.rb:260:in `api'
[   50s]      # /home/abuild/rpmbuild/BUILD/yast2-nis-client-4.4.1/src/modules/Nis.rb:1277:in `Write'
[   50s]      # ./nis_test.rb:127:in `block (3 levels) in <top (required)>'
[   50s]      # ------------------
[   50s]      # --- Caused by: ---
[   50s]      # Cheetah::ExecutionFailed:
[   50s]      #   Execution of "firewall-cmd --state" failed with status 127: No such file or directory - firewall-cmd.
[   50s]      #   /usr/share/YaST2/lib/yast2/execute.rb:176:in `block in run'
```