### PR TITLE
Obsolete package for TW 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# YaST - The NIS Client Module #
+
+Obsoleted Repository
+====================
+
+**This repository is obsoleted and it is not developed anymore.**
+
+The package *yast2-nis-client* is only maitained for *SUSE SLE 15* and *openSUSE Leap 15* products.
+No new features will be implemented and the packate will be dropped from future products. *Tumbleweed*
+does not provide this package anymore.
 
 [![Workflow Status](https://github.com/yast/yast-nis-client/workflows/CI/badge.svg?branch=master)](
 https://github.com/yast/yast-nis-client/actions?query=branch%3Amaster)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle_latest
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Mar 25 15:48:05 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Obsolete package for Tumbleweed (bsc#1183893).
+
+-------------------------------------------------------------------
 Thu Jan 27 10:31:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed testsuite failure during RPM build (bsc#1195194)


### PR DESCRIPTION
## Problem

NIS is very old and it should not be used. The package *yast2-nis-client* should not be included in TW anymore.

* https://bugzilla.suse.com/show_bug.cgi?id=1183893
* https://trello.com/c/nvcUvZ93/2896-2-drop-yast-nis-from-tw

See also https://github.com/yast/yast-nis-server/pull/30.

## Solution

Only submit to SLE. Note that *yast2-nis-client* will not be removed from SLE-15 yet. It will be only maintained, no new features. Added note to README to indicate the status of this module.

Note: This PR will not be submitted to Factory because the jenkins job in ci.opensuse.org was already removed.
Note: This PR will not be merged into master yet. The temporary branch *pre-SLE-15-SP4* will be merged into master after *SLE-15-SP4* branching. Do not forget to bump the version while merging.

