### PR TITLE
[master] Obsolete package and drop from TW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# YaST - The NIS Client Module #
+
+Obsoleted Repository
+====================
+
+**This repository is obsoleted and it is not developed anymore.**
+
+The package *yast2-nis-client* is only maitained for *SUSE SLE 15* and *openSUSE Leap 15* products.
+No new features will be implemented and the packate will be dropped from future products. *Tumbleweed*
+does not provide this package anymore.
 
 [![Workflow Status](https://github.com/yast/yast-nis-client/workflows/CI/badge.svg?branch=master)](
 https://github.com/yast/yast-nis-client/actions?query=branch%3Amaster)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle_latest
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-nis-client.changes
+++ b/package/yast2-nis-client.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Apr  8 13:38:41 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Obsolete package for Tumbleweed (bsc#1183893).
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (#bsc1198109)


### PR DESCRIPTION
Just merging https://github.com/yast/yast-nis-client/pull/63 to master (was blocked by creating the SP4 branch).